### PR TITLE
New syntax

### DIFF
--- a/files/512bitx10.zok
+++ b/files/512bitx10.zok
@@ -2,7 +2,7 @@ import "hashes/sha256/512bit" as sha256
 
 def main(u32[8] a) -> (u32[8]):
 	u32[8] digest = sha256(a, a)
-	for field i in 0..9 do
+	for u32 i in 0..9 do
 		u32[8] temp = sha256(digest, digest)
 		digest = temp
 	endfor

--- a/files/getHexLength.zok
+++ b/files/getHexLength.zok
@@ -1,46 +1,18 @@
 import "utils/pack/bool/unpack128.zok" as unpack_field_to_128_bool
+import "utils/casts/u32_to_field.zok" as to_field
 
-def get_bit_length(field word) -> (field):
+def get_bit_length(field word) -> u32:
     bool[128] unpacked_word = unpack_field_to_128_bool(word)
-    field result = 0
-    for field i in 0..128 do
+    u32 result = 0
+    for u32 i in 0..128 do
         result = if (result == 0) && (unpacked_word[i] == true) then 128-i else result fi
     endfor
 return result
 
-def main(field word) -> (field):
-    field bit_length = get_bit_length(word)
-    field result = 0
-    result = if bit_length > 0 then 1 else result fi
-    result = if bit_length > 4 then 2 else result fi
-    result = if bit_length > 8 then 3 else result fi
-    result = if bit_length > 12 then 4 else result fi
-    result = if bit_length > 16 then 5 else result fi
-    result = if bit_length > 20 then 6 else result fi
-    result = if bit_length > 24 then 7 else result fi
-    result = if bit_length > 28 then 8 else result fi
-    result = if bit_length > 32 then 9 else result fi
-    result = if bit_length > 36 then 10 else result fi
-    result = if bit_length > 40 then 11 else result fi
-    result = if bit_length > 44 then 12 else result fi
-    result = if bit_length > 48 then 13 else result fi
-    result = if bit_length > 52 then 14 else result fi
-    result = if bit_length > 56 then 15 else result fi
-    result = if bit_length > 60 then 16 else result fi
-    result = if bit_length > 64 then 17 else result fi
-    result = if bit_length > 68 then 18 else result fi
-    result = if bit_length > 72 then 19 else result fi
-    result = if bit_length > 76 then 20 else result fi
-    result = if bit_length > 80 then 21 else result fi
-    result = if bit_length > 84 then 22 else result fi
-    result = if bit_length > 88 then 23 else result fi
-    result = if bit_length > 92 then 24 else result fi
-    result = if bit_length > 96 then 25 else result fi
-    result = if bit_length > 100 then 26 else result fi
-    result = if bit_length > 104 then 27 else result fi
-    result = if bit_length > 108 then 28 else result fi
-    result = if bit_length > 112 then 29 else result fi
-    result = if bit_length > 116 then 30 else result fi
-    result = if bit_length > 120 then 31 else result fi
-    result = if bit_length > 124 then 32 else result fi
-return result
+def main(field word) -> u32:
+    u32 bit_length = get_bit_length(word)
+    u32 result = 0
+    for u32 i in 0..32 do
+        result = if bit_length > 4 * i then i else result fi
+    endfor
+    return result

--- a/files/zkRelay_val.zok
+++ b/files/zkRelay_val.zok
@@ -4,99 +4,61 @@ import "utils/casts/u32_4_to_bool_128.zok" as u32_4_to_bool_128
 import "utils/pack/bool/pack128.zok" as pack_128_bool_to_field
 import "utils/pack/bool/unpack128.zok" as unpack_field_to_128_bool
 import "utils/pack/u32/unpack128.zok" as unpack_field_to_4_u32
+import "utils/casts/u32_to_field" as to_field
 import "hashes/sha256/1024bit.zok" as sha256for1024
 import "hashes/sha256/256bitPadded.zok" as sha256only
 import "./getHexLength.zok" as getHexLength
 
-def toBigEndian(bool[32] value) -> (bool[32]):
-    return [
-            ...value[24..32],
-            ...value[16..24],
-            ...value[8..16],
-            ...value[0..8]]
+def toBigEndian<N>(bool[N] value) -> (bool[N]):
+    assert(N % 8u32 == 0)
+    bool[N] result = [false; N]
 
-def toBigEndian(bool[24] value) -> (bool[24]):
-    return [
-            ...value[16..24],
-            ...value[8..16],
-            ...value[0..8]]
+    for u32 i in 0..N / 8 do
+        for u32 j in 0..8 do
+            result[8 * i + j] = value[N - 8 * (i + 1) + j]
+        endfor
+    endfor
 
-def toBigEndian(bool[128] value) -> (bool[128]):
-    return [
-            ...value[120..128],
-            ...value[112..120],
-            ...value[104..112],
-            ...value[96..104],
-            ...value[88..96],
-            ...value[80..88],
-            ...value[72..80],
-            ...value[64..72],
-            ...value[56..64],
-            ...value[48..56],
-            ...value[40..48],
-            ...value[32..40],
-            ...value[24..32],
-            ...value[16..24],
-            ...value[8..16],
-            ...value[0..8]]
+    return result
 
-def packMaxVariance(field length) -> (field):
+def packMaxVariance(u32 length) -> field:
     field result = 0
-    result = if length == 1 then pack_128_bool_to_field([...[false; 124], ...[true; 4]]) else result fi
-    result = if length == 2 then pack_128_bool_to_field([...[false; 120], ...[true; 8]]) else result fi
-    result = if length == 3 then pack_128_bool_to_field([...[false; 116], ...[true; 12]]) else result fi
-    result = if length == 4 then pack_128_bool_to_field([...[false; 112], ...[true; 16]]) else result fi
-    result = if length == 5 then pack_128_bool_to_field([...[false; 108], ...[true; 20]]) else result fi
-    result = if length == 6 then pack_128_bool_to_field([...[false; 104], ...[true; 24]]) else result fi
-    result = if length == 7 then pack_128_bool_to_field([...[false; 100], ...[true; 28]]) else result fi
-    result = if length == 8 then pack_128_bool_to_field([...[false; 96], ...[true; 32]]) else result fi
-    result = if length == 9 then pack_128_bool_to_field([...[false; 92], ...[true; 36]]) else result fi
-    result = if length == 10 then pack_128_bool_to_field([...[false; 88], ...[true; 40]]) else result fi
-    result = if length == 11 then pack_128_bool_to_field([...[false; 84], ...[true; 44]]) else result fi
-    result = if length == 12 then pack_128_bool_to_field([...[false; 80], ...[true; 48]]) else result fi
-    result = if length == 13 then pack_128_bool_to_field([...[false; 76], ...[true; 52]]) else result fi
-    result = if length == 14 then pack_128_bool_to_field([...[false; 72], ...[true; 56]]) else result fi
-    result = if length == 15 then pack_128_bool_to_field([...[false; 68], ...[true; 60]]) else result fi
-    result = if length == 16 then pack_128_bool_to_field([...[false; 64], ...[true; 64]]) else result fi
-    result = if length == 17 then pack_128_bool_to_field([...[false; 60], ...[true; 68]]) else result fi
-    result = if length == 18 then pack_128_bool_to_field([...[false; 56], ...[true; 72]]) else result fi
-    result = if length == 19 then pack_128_bool_to_field([...[false; 52], ...[true; 76]]) else result fi
-    result = if length == 20 then pack_128_bool_to_field([...[false; 48], ...[true; 80]]) else result fi
-    result = if length == 21 then pack_128_bool_to_field([...[false; 44], ...[true; 84]]) else result fi
-    result = if length == 22 then pack_128_bool_to_field([...[false; 40], ...[true; 88]]) else result fi
-    result = if length == 23 then pack_128_bool_to_field([...[false; 36], ...[true; 92]]) else result fi
-    result = if length == 24 then pack_128_bool_to_field([...[false; 32], ...[true; 96]]) else result fi
-    result = if length == 25 then pack_128_bool_to_field([...[false; 28], ...[true; 100]]) else result fi
-    result = if length == 26 then pack_128_bool_to_field([...[false; 24], ...[true; 104]]) else result fi
-    result = if length == 27 then pack_128_bool_to_field([...[false; 20], ...[true; 108]]) else result fi
-    result = if length == 28 then pack_128_bool_to_field([...[false; 16], ...[true; 112]]) else result fi
-    result = if length == 29 then pack_128_bool_to_field([...[false; 12], ...[true; 116]]) else result fi
-    result = if length == 30 then pack_128_bool_to_field([...[false; 8], ...[true; 120]]) else result fi
-    result = if length == 31 then pack_128_bool_to_field([...[false; 4], ...[true; 124]]) else result fi
-    result = if length == 32 then pack_128_bool_to_field([true; 128]) else result fi
-return result
+    for u32 i in 1..33 do
+        result = if length == i then pack_128_bool_to_field([...[false; 128 - 4 * i], ...[true; 4 * i]]) else result fi
+    endfor
+    return result
 
 def packTarget(bool[32] bits) -> (field):
-    field result =     if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 23 then pack_128_bool_to_field([...[false; 72], ...bits[8..32], ...[false; 32]]) else       if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 24 then pack_128_bool_to_field([...[false; 64], ...bits[8..32], ...[false; 40]]) else         if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 25 then pack_128_bool_to_field([...[false; 56], ...bits[8..32], ...[false; 48]]) else           if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 26 then pack_128_bool_to_field([...[false; 48], ...bits[8..32], ...[false; 56]]) else             if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 27 then pack_128_bool_to_field([...[false; 40], ...bits[8..32], ...[false; 64]]) else               if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 28 then pack_128_bool_to_field([...[false; 32], ...bits[8..32], ...[false; 72]]) else                 if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 29 then pack_128_bool_to_field([...[false; 24], ...bits[8..32], ...[false; 80]]) else                   if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 30 then pack_128_bool_to_field([...[false; 16], ...bits[8..32], ...[false; 88]]) else                     if pack_128_bool_to_field([...[false; 120], ...bits[0..8]]) == 31 then pack_128_bool_to_field([...[false; 8], ...bits[8..32], ...[false; 96]]) else                     pack_128_bool_to_field([false; 128]) fi                   fi                 fi               fi             fi           fi         fi       fi     fi
-return result
 
-def get_bit_length_bits(bool[24] bits) -> (field):
-    field result = 0
-    for field i in 0..24 do
+    field packed = pack_128_bool_to_field([...[false; 120], ...bits[0..8]])
+
+    field result = pack_128_bool_to_field([false; 128])
+
+    for u32 i in 0..9 do
+        result =\
+            if packed == 32 - to_field(i) - 1 then\
+                pack_128_bool_to_field([...[false; 8 * (i + 1)], ...bits[8..32], ...[false; 96 - 8 * i]])\
+            else\
+                result\
+            fi
+    endfor
+
+    return result
+
+def get_bit_length_bits(bool[24] bits) -> (u32):
+    u32 result = 0
+    for u32 i in 0..24 do
         result = if (result == 0) && (bits[i] == true) then 24-i else result fi
     endfor
 return result
 
-def get_hex_length_bits(bool[24] bits) -> (field):
-    field bit_length = get_bit_length_bits(bits)
-    field result = 0
-    result = if bit_length > 0 then 1 else result fi
-    result = if bit_length > 4 then 2 else result fi
-    result = if bit_length > 8 then 3 else result fi
-    result = if bit_length > 12 then 4 else result fi
-    result = if bit_length > 16 then 5 else result fi
-    result = if bit_length > 20 then 6 else result fi
-return result
+def get_hex_length_bits(bool[24] bits) -> u32:
+    u32 bit_length = get_bit_length_bits(bits)
+    u32 result = 0
+    for u32 i in 0..6 do
+        result = if bit_length > 4 * i then i else result fi
+    endfor
+    return result
 
 // call with last field of block array
 def validate_target(field epoch_head, u32 epoch_tail, u32 next_epoch_head) -> (bool, field):
@@ -119,18 +81,19 @@ def validate_target(field epoch_head, u32 epoch_tail, u32 next_epoch_head) -> (b
 
     // The encoding of targets uses a floor function, the comparison of a calculated target may therefore fail
     // Therefore, a maximum variance is calculated that is one hex digit in the encoding
-    field maxVariance = packMaxVariance(getHexLength(target)-get_hex_length_bits(toBigEndian(next_epoch_head_unpacked[0..24])))
+    field maxVariance = packMaxVariance(getHexLength(target) - get_hex_length_bits(toBigEndian(next_epoch_head_unpacked[0..24])))
+    
     // int('ffff' + 10 * '00', 16) * 2016 * 600 = 95832923060582736897701037735936000
     target = if target > 95832923060582736897701037735936000 then 95832923060582736897701037735936000 else target fi
     field delta = target - encoded_target_extended
     delta = if target >= encoded_target_extended then delta else maxVariance + 1 fi
     bool valid = if delta <= maxVariance then true else false fi
-    //field valid = if (37202390668975264121251936602161152-81015268229227203625641762304819200) < 1267650600228229401496703205375 then 1 else 0 fi
     return valid, current_target
 
 def validate_block_header(u32 reference_target, u32[8] prev_block_hash, u32[20] preimage) -> (u32[8]):
 	// preImage: [0] -> Block version, [1:8] -> prev_block_hash, [9:16] -> merkle root, [17:19] => time, target, nonce 
-    assert(preimage[1] == prev_block_hash[0] &&             preimage[2] == prev_block_hash[1] &&             preimage[3] == prev_block_hash[2] &&             preimage[4] == prev_block_hash[3] &&             preimage[5] == prev_block_hash[4] &&             preimage[6] == prev_block_hash[5] &&             preimage[7] == prev_block_hash[6] &&             preimage[8] == prev_block_hash[7])
+    assert(preimage[1..9] == prev_block_hash[0..8])
+    
     // converting to big endian is not necessary here, as reference target is encoded little endian
     assert(preimage[18] == reference_target)
     u32[8] intermediary = sha256for1024(preimage[0..8], preimage[8..16], [...preimage[16..20], 0x80000000, ...[0x00000000; 3]], [...[0x00000000; 7], 0x00000280])
@@ -146,8 +109,8 @@ def main(field epoch_head, u32[8] prev_block_hash, private u32[2][20] intermedia
     u32 reference_target = unpack_field_to_4_u32(epoch_head)[2]
 
     u32[8] block_hash = prev_block_hash
-    u32[3][8] blocks = [[0x00000000;8];3]
-    for field i in 0..2 do
+    u32[3][8] blocks = [[0x00000000; 8]; 3]
+    for u32 i in 0..2 do
       block_hash = validate_block_header(reference_target, block_hash, intermediate_blocks[i])
       blocks[i] = block_hash
     endfor


### PR DESCRIPTION
Hey @petscheit !

I had a look at this and it seems like I've identified the memory issue and fixed it. It will be available hopefully soon on the develop branch, as it depends on some pretty deep refactoring related to generic functions. At the end I'm able to compile `zkRelay_val` on my 2017 MBP 16gb RAM in 25 seconds using 500MB of memory.

Here are some syntax improvements which I identified. Note that
- I have not tested these for correctness, only made sure the program compiles
- these rely on syntax extensions introduced with generic functions, so they are not all usable today on master, but maybe it's good to keep this PR open to be able to compare and upgrade once these compiler changes are released.

Thanks for your time trying to debug these memory issues, hopefully it'll be smoother very soon!